### PR TITLE
Fix WHOIS expiry parsing for CSV output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Script Bash untuk memeriksa status domain dan tanggal expired baik **domain inte
 * Mengambil tanggal expired domain via **WHOIS global** atau **PANDI (khusus .id)**.
 * Menampilkan **progress bar + persentase + ETA**.
 * Menyimpan hasil ke file **CSV** dengan format aman (quoted).
+* Parser WHOIS menjaga kolom **Expiry Date** tetap utuh (termasuk jam & zona) untuk domain internasional.
 * Menyimpan log detail ke file **LOG** dengan header & footer.
 * Auto install dependency (`whois`, `dig`, `curl`, `grep`).
 * Highlight otomatis:
@@ -234,7 +235,7 @@ Supported by SatpamSiber.com | AhliWeb.com | AhliWeb.co.id | AhliWeb.my.id
 **CSV aman (quoted)**: `"Domain","Status","Expiry Date","Note"`
 
 * `Status`: `Active`/`Inactive` (untuk `Active` dapat memuat IP pertama, mis. `Active (203.0.113.10)`).
-* `Expiry Date`: ISO‑8601 UTC atau `(N/A)` jika tidak ditemukan.
+* `Expiry Date`: ISO‑8601 UTC lengkap (contoh: `2026-02-21T08:56:22Z`) atau `(N/A)` jika tidak ditemukan.
 * `Note`: `❌ Expired`, `⚠️ Expiring Soon (≤30 hari)`, `✅ OK`, atau penjelasan jika expiry tak ditemukan.
 
 **LOG**:

--- a/check_domains.sh
+++ b/check_domains.sh
@@ -109,14 +109,14 @@ ensure_tools() {
 extract_expiry_whois() {
   grep -iE 'Registry Expiry Date|Expiry Date|Expiration Date|paid-till|expire' \
     | head -n 1 \
-    | sed -E 's/.*:[[:space:]]*//; s/\r$//'
+    | sed -E 's/^[^:]*:[[:space:]]*//; s/\r$//'
 }
 
 # Parser WHOIS (spesial TLD/registrar), mis. .top menggunakan field Registrar Registration Expiration Date
 extract_expiry_special() {
   grep -iE 'Registrar Registration Expiration Date|Domain Expiration Date|Expiry|Expires On' \
     | head -n 1 \
-    | sed -E 's/.*:[[:space:]]*//; s/\r$//'
+    | sed -E 's/^[^:]*:[[:space:]]*//; s/\r$//'
 }
 
 # Hitung sisa hari dari string tanggal yang bisa dipahami `date -d`


### PR DESCRIPTION
## Summary
- update WHOIS parsing in the shell script so expiry timestamps with time components are no longer truncated
- document in the README that CSV expiry dates retain the full ISO-8601 value

## Testing
- bash -n check_domains.sh

------
https://chatgpt.com/codex/tasks/task_e_68e0e5feb994832a9263af5c02df1128